### PR TITLE
Fixed trace and propagation (w3c)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,18 @@ After the installation, go to the settings (gear icon at the top of Docker Deskt
 
 ## Running with Tilt
 
-Under the directory `ruby`, you will find a series of directories such as:
-- 01-manual
-- 01-start-manual
-- 02-_start_asynchronous
-- 03-span-events
-- 04-span_links
-- ruby-greeting-services
+Under the directory `ruby`, you will find a series of directories. Please refer to the table below to understand what they are and how to use it.
+
+|Directory|Entrypoint (curl)|What it is|
+|---|---|---|
+|01-manual|`curl http://localhost:6001/year`||
+|01-start-manual|`curl http://localhost:6001/year`||
+|02-_start_asynchronous|`curl http://localhost:6001/year`||
+|03-span-events|`curl http://localhost:6001/year`||
+|04-span-links|`curl http://localhost:6001/year`||
+|05-propagation|`curl http://localhost:8000/name`||
+|05-start-propagation|`curl http://localhost:8000/name`||
+|ruby-greeting-services|`curl http://localhost:6001/year`||
 
 ### Server apps
 In each directories, there is a `Tiltfile` to run these services on a local host using <https://tilt.dev/>.

--- a/ruby/01-start-manual/year-service/Gemfile
+++ b/ruby/01-start-manual/year-service/Gemfile
@@ -5,3 +5,4 @@ gem 'opentelemetry-exporter-otlp'
 gem 'opentelemetry-instrumentation-all'
 gem "grape"
 gem "puma"
+gem "async-await"

--- a/ruby/05-start-propagation/name-service/name.rb
+++ b/ruby/05-start-propagation/name-service/name.rb
@@ -11,6 +11,10 @@ Honeycomb.configure do |config|
   # missing something to ensure it reports
   # config.client = Libhoney::LogClient.new
   # config.debug = true
+  config.http_trace_parser_hook do |env|
+    Honeycomb::W3CPropagation::UnmarshalTraceContext.parse_rack_env env
+  end
+
   config.http_trace_propagation_hook do |env, context|
     Honeycomb::W3CPropagation::MarshalTraceContext.parse_faraday_env env, context
   end

--- a/ruby/05-start-propagation/name-service/name.rb
+++ b/ruby/05-start-propagation/name-service/name.rb
@@ -6,9 +6,14 @@ require 'faraday'
 Honeycomb.configure do |config|
   config.write_key = ENV['HONEYCOMB_API_KEY']
   config.service_name = ENV['SERVICE_NAME'] || 'name-ruby'
-  config.api_host = ENV['HONEYCOMB_API_ENDPOINT']
+  config.dataset = ENV['SERVICE_NAME'] || 'name-ruby'
+  # config.api_host = ENV['HONEYCOMB_API_ENDPOINT']
   # missing something to ensure it reports
-  config.client = Libhoney::LogClient.new
+  # config.client = Libhoney::LogClient.new
+  # config.debug = true
+  config.http_trace_propagation_hook do |env, context|
+    Honeycomb::W3CPropagation::MarshalTraceContext.parse_faraday_env env, context
+  end
 end
 
 use Honeycomb::Sinatra::Middleware, client: Honeycomb.client
@@ -30,14 +35,19 @@ names_by_year = {
 }
 
 get '/name' do
-  year = get_year
-  names = names_by_year[year]
-  names[rand(names.length)]
+  Honeycomb.start_span(name: 'name') do
+    year = get_year
+    names = names_by_year[year]
+    name = names[rand(names.length)]
+    Honeycomb.add_field('name', name)
+    Honeycomb.add_field('year', year)
+    name + " " + year.to_s
+  end
 end
 
 def get_year
   year_service_connection = Faraday.new(ENV['YEAR_ENDPOINT'] || 'http://localhost:6001')
-  Honeycomb.start_span(name: 'honeycomb_trace') do
+  Honeycomb.start_span(name: 'get_year') do
     year_service_response = year_service_connection.get('/year') do |request|
     end
     year_service_response.body.to_i


### PR DESCRIPTION
Looked like honeycomb's beeline requires `config.dataset` also added as service name (contrast to what was described in the documentation https://docs.honeycomb.io/troubleshoot/product-lifecycle/recommended-migrations/migrate-from-beelines/ruby/#hnyInfo-current-mode. You must specify the config.dataset. I have a feeling that this was a bug.

Also, w3c propagation does NOT just work.
You have to set the following:
```
  config.http_trace_propagation_hook do |env, context|
    Honeycomb::W3CPropagation::MarshalTraceContext.parse_faraday_env env, context
  end
```
in Honeycomb.configure to make it work.

Also added some logic to add attributes to record which name and year the trace produced :-).
